### PR TITLE
ci: add CLI smoke test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,14 @@ jobs:
       - run: uv sync --extra dev
       - run: uv run pyright src/
 
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - run: uv sync --extra dev
+      - run: bash scripts/run_cli_smoke.sh
+
   test:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
## Summary
- Adds a new `smoke` job to the CI workflow that runs `scripts/run_cli_smoke.sh`
- This exercises all 5 CLI commands (timeline, bar, line, bubble, summarise) plus an error-path check end-to-end
- Catches packaging, entry point, and data file availability issues that unit tests don't cover

## Test plan
- [ ] Verify the new `smoke` job passes in CI
- [ ] Confirm existing jobs (lint, docs, typecheck, test) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)